### PR TITLE
Add Dependabot config and code owners spec

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @josephgruber


### PR DESCRIPTION
Add's an initial Dependabot config for `uv` along with an initial code owners spec